### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,10 +222,10 @@ Application keybinds, tweaked to layout by setting `config.keyboard.active`:
 | [system configuration](https://search.nixos.org/options) | [`./hosts/`](https://codeberg.org/kiara/cfg/src/branch/main/hosts/) |
 | [home-manager configuration](https://nix-community.github.io/home-manager/options.xhtml) | [`./home-manager/`](https://codeberg.org/kiara/cfg/src/branch/main/home-manager/) |
 | binaries and command wrappers | [`./home-manager/kiara/commands.nix`](https://codeberg.org/kiara/cfg/src/branch/main/home-manager/commands.nix) |
-| reusable [modules](https://nixos.wiki/wiki/Module) | [`./modules/`](https://codeberg.org/kiara/cfg/src/branch/main/modules) |
+| reusable [modules](https://wiki.nixos.org/wiki/Module) | [`./modules/`](https://codeberg.org/kiara/cfg/src/branch/main/modules) |
 | custom [functions](https://noogle.dev/) | [`./lib/`](https://codeberg.org/kiara/cfg/src/branch/main/lib) |
 | [custom packages](https://blog.ielliott.io/nix-docs/mkDerivation.html) | [`./pkgs/*.nix`](https://codeberg.org/kiara/cfg/src/branch/main/pkgs) (from flake inputs: [`./pkgs/default.nix`](https://codeberg.org/kiara/cfg/src/branch/main/pkgs/default.nix)) |
-| [overlays](https://nixos.wiki/wiki/Overlays) | [`./overlays/*.nix`](https://codeberg.org/kiara/cfg/src/branch/main/overlays) (from flake inputs: [`./flake.nix`](https://codeberg.org/kiara/cfg/src/branch/main/flake.nix)) |
+| [overlays](https://wiki.nixos.org/wiki/Overlays) | [`./overlays/*.nix`](https://codeberg.org/kiara/cfg/src/branch/main/overlays) (from flake inputs: [`./flake.nix`](https://codeberg.org/kiara/cfg/src/branch/main/flake.nix)) |
 | [LSP](https://langserver.org/) (vscodium / [coc.nvim](https://github.com/neoclide/coc.nvim)) | [`./home-manager/kiara/features/development/`](https://codeberg.org/kiara/cfg/src/branch/main/home-manager/kiara/features/development/) |
 | shell scripts | [`./home-manager/kiara/scripts/*.sh`](https://codeberg.org/kiara/cfg/src/branch/main/home-manager/kiara/scripts/) |
 | [dotfiles](https://www.freecodecamp.org/news/dotfiles-what-is-a-dot-file-and-how-to-create-it-in-mac-and-linux/) | [`./home-manager/kiara/dotfiles/`](https://codeberg.org/kiara/cfg/src/branch/main/home-manager/kiara/dotfiles/) + [`./home-manager/kiara/dotfiles.nix`](https://codeberg.org/kiara/cfg/src/branch/main/home-manager/kiara/dotfiles.nix) |

--- a/home-manager/kiara/chromebook.nix
+++ b/home-manager/kiara/chromebook.nix
@@ -1,4 +1,4 @@
-# https://nixos.wiki/wiki/Installing_Nix_on_Crostini
+# https://wiki.nixos.org/wiki/Installing_Nix_on_Crostini
 {pkgs, ...}: {
   # register desktop applications
   xdg.configFile."systemd/user/cros-garcon.service.d/override.conf".text = ''

--- a/home-manager/kiara/commands.nix
+++ b/home-manager/kiara/commands.nix
@@ -124,7 +124,7 @@ let
     lib.dryCommands binaries
     //
     # misc: either using args, or key != package name.
-    # in case of args, consider a [wrapping overlay/script](https://nixos.wiki/wiki/Wrappers_vs._Dotfiles).
+    # in case of args, consider a [wrapping overlay/script](https://wiki.nixos.org/wiki/Wrappers_vs._Dotfiles).
     {
       rofi = "${config.programs.rofi.package}/bin/rofi -i";
       rofi-systemd = "${rofi-systemd}/bin/.rofi-systemd-wrapped";

--- a/home-manager/kiara/firefox.nix
+++ b/home-manager/kiara/firefox.nix
@@ -56,7 +56,7 @@
         #   #     definedAliases = [ "@nms" ];
         #   #   };
         #   #   "NixOS-Wiki Search" = {
-        #   #     urls = [{ template = "https://nixos.wiki/index.php?search={searchTerms}&go=Go"; }];
+        #   #     urls = [{ template = "https://wiki.nixos.org/index.php?search={searchTerms}&go=Go"; }];
         #   #     iconUpdateURL = "https://nixos.org/favicon.png";
         #   #     definedAliases = [ "@nws" ];
         #   #   };
@@ -120,7 +120,7 @@
         #       {
         #         name = "wiki";
         #         tags = [ "wiki" "nix" ];
-        #         url = "https://nixos.wiki/";
+        #         url = "https://wiki.nixos.org/";
         #       }
         #     ];
         #   }

--- a/home-manager/kiara/home.nix
+++ b/home-manager/kiara/home.nix
@@ -49,7 +49,7 @@
   # You can update Home Manager without changing this value. See
   # the Home Manager release notes for a list of state version
   # changes in each release.
-  # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion
+  # https://wiki.nixos.org/wiki/FAQ/When_do_I_update_stateVersion
   home.stateVersion = "22.11";
 
   # Let Home Manager install and manage itself.

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,4 +1,4 @@
-# Add your reusable home-manager modules to this directory, on their own file (https://nixos.wiki/wiki/Module).
+# Add your reusable home-manager modules to this directory, on their own file (https://wiki.nixos.org/wiki/Module).
 # These should be stuff you would like to share with others, not your personal configurations.
 {...}: {
   # List your module files here

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,4 +1,4 @@
-# Add your reusable NixOS modules to this directory, on their own file (https://nixos.wiki/wiki/Module).
+# Add your reusable NixOS modules to this directory, on their own file (https://wiki.nixos.org/wiki/Module).
 # These should be stuff you would like to share with others, not your personal configurations.
 {
   # List your module files here

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,6 +1,6 @@
 # Packages you want to overlay.
 # You can change versions, add patches, set compilation flags, anything really.
-# https://nixos.wiki/wiki/Overlays
+# https://wiki.nixos.org/wiki/Overlays
 {
   lib,
   pkgs,


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️